### PR TITLE
Generate a 404.html for not found files, and try to guess old links

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -174,8 +174,9 @@ def main():
     mapping = make_mapping('.') | count_authorities
     g.render('index.tmpl', f'{dest_dir}', mapping)
     g.render('about.tmpl', f'{dest_dir}/about.html', mapping)
-    mapping = make_mapping('..')
     g.render('ref.tmpl', f'{dest_dir}/ref/', mapping)
+    mapping = make_mapping('') # relative paths do not work in a 404. It can be anywhere
+    g.render('404.tmpl', f'{dest_dir}/404.html', mapping)
 
     mapping = make_mapping('../..')
     for authority in authorities.keys():

--- a/scripts/templates/404.tmpl
+++ b/scripts/templates/404.tmpl
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    {% include 'sections/head.tmpl' %}
+    <title>Home -- 404 - Page not found</title>
+</head>
+
+<body>
+    <div id="header">
+        {% include 'sections/header.tmpl' %}
+        <div id="header_title">
+            404 - Page not found
+        </div>
+    </div>
+    <div id="searchbox">
+        {% include 'sections/searchbox.tmpl' %}
+    </div>
+
+    <div id="navbar">
+        {% include 'sections/navbar.tmpl' %}
+    </div>
+
+    <div id="content" style="text-align: center;">
+        <h1>404</h1>
+        <h2>File not found</h2>
+        <p id="not_found_cont"></p>
+    </div>
+    <div id="footer">
+        {% include 'sections/footer.tmpl' %}
+    </div>
+    <script src="{{ home_dir }}/base.js"></script>
+    <script>
+        not_found("{{ home_dir }}")
+    </script>
+</body>


### PR DESCRIPTION
Google has some old links, like `https://spatialreference.org/ref/epsg/anguilla-1957-british-west-indies-grid/` 
To see that just click the link to "Google it" in any reference system (as today. I hope Google is updating the information at some point).

With this PR we have a dedicated 404 page (with a similar style), and also try to find if the url was from a known reference system. In that case, a message is shown and redirected after 5 s.

```
404
File not found

However, apparently you want to visit

EPSG:2000
Anguilla 1957 / British West Indies Grid

Redirecting to http://spatialreference.org/ref/epsg/2000
```