### PR TITLE
Fix minor typo in crs.tmpl

### DIFF
--- a/scripts/templates/crs.tmpl
+++ b/scripts/templates/crs.tmpl
@@ -29,7 +29,7 @@
         <p>
           {%- if epsg_scaped_name %}
             View <a href="https://epsg.org/crs_{{ code }}/{{ epsg_scaped_name }}.html" target="_blank">
-            EPSG.org defintion for EPSG:{{ code }}</a> |
+            EPSG.org definition for EPSG:{{ code }}</a> |
           {%- endif %}
             <a href="http://www.google.com/search?q={{ name }}" target="_blank">Google it</a>
         </p>


### PR DESCRIPTION
A small typo but it shows up on every CRS definition