### PR TITLE
crs.tmpl: add a comment about proj4 being a deprecated format

### DIFF
--- a/scripts/templates/crs.tmpl
+++ b/scripts/templates/crs.tmpl
@@ -74,7 +74,7 @@
             <li><a href="esriwkt.txt">ESRI WKT</a></li>
             <li><a href="#" onclick="download_prj('{{ code }}.prj', 'esriwkt.txt')" title="Download as PRJ file from ESRI">.PRJ</a></li>
             <li><a href="projjson.json" title="PROJJSON">JSON</a></li>
-            <li><a href="proj4.txt">Proj4</a></li>
+            <li><a href="proj4.txt">Proj4</a> (deprecated format)</li>
         </ul>
         </div>
 


### PR DESCRIPTION
(ideally we should point to some page on proj.org indicating why, but I can't find an existing one)