### PR TITLE
Search improvements

### DIFF
--- a/scripts/templates/base.js
+++ b/scripts/templates/base.js
@@ -73,23 +73,13 @@ function paramsToDic(location) {
 
 function filter_data(data, search, authority) {
     if (!search || !search.trim()) {
-        search = ''
+        search = '';
     }
-    let authorities = [authority]
     let s = search.toUpperCase().split(' ');
-    if (!authority) {
-        let possible_authorities = ['EPSG', 'ESRI', 'IAU_2015', 'IGNF', 'NKG', 'OGC']
-        authorities = s
-            .map(a => a.split(':')[0])
-            .filter(a => possible_authorities.includes(a));
 
-        s = s.filter(a => !possible_authorities.includes(a))
-            .map(a => {
-                if (possible_authorities.includes(a.split(':')[0])) {
-                    return a.slice(a.indexOf(':') + 1);
-                }
-                return a;
-        });
+    let auth_code = [null, s.length ? s[0] : null];
+    if (s.length == 1 && s[0].split(':').length == 2) {
+        auth_code = s[0].split(':');
     }
 
     let r = data.filter(d => {
@@ -102,11 +92,12 @@ function filter_data(data, search, authority) {
         }
         let valid = (outlier == undefined);
 
-        if (!isNaN(s[0]) && d.code === s[0]) {
-            valid = true
+        if (!isNaN(auth_code[1]) && d.code === auth_code[1] && (!auth_code[0] || d.auth_name === auth_code[0])) {
+            // filter by code or auth:code
+            valid = true;
         }
-        if (authorities.length && !authorities.includes(d.auth_name)) {
-            valid = false
+        if (authority && authority !== d.auth_name) {
+            valid = false;
         }
         return valid;
     });

--- a/scripts/templates/base.js
+++ b/scripts/templates/base.js
@@ -94,7 +94,13 @@ function filter_data(data, search, authority) {
 
     let r = data.filter(d => {
         let name = d.name.toUpperCase();
-        let valid = s.reduce((accum, current) => accum && name.includes(current), true);
+        let outlier = s.find(elem => !name.includes(elem));
+        if (outlier == "WGS84") {
+            // many people searches WGS84, however the EPSG name has a space: "WGS 84"
+            const s2 = s.map(elem => elem == "WGS84" ? "WGS 84" : elem);
+            outlier = s2.find(elem => !name.includes(elem));
+        }
+        let valid = (outlier == undefined);
 
         if (!isNaN(s[0]) && d.code === s[0]) {
             valid = true

--- a/scripts/templates/tests.html
+++ b/scripts/templates/tests.html
@@ -20,6 +20,12 @@
         <li><a href="./ref/epsg/?search=utm+32">Search "utm 32" in EPSG</a></li>
         <li><a href="./ref/epsg/?search=Locodjo+1965+%2F+UTM">Search "Locodjo 1965 / UTM"</a></li>
         <li></li>
+        <li><a href="./ref/?search=4326">Search "4326"</a></li>
+        <li><a href="./ref/epsg/?search=4326">Search "4326" in EPSG</a></li>
+        <li><a href="./ref/?search=epsg%3A4326">Search "epsg:4326"</a></li>
+        <li><a href="./ref/epsg/?search=epsg%3A4326">Search "epsg:4326" in EPSG</a></li>
+        <li><a href="./ref/esri/?search=epsg%3A4326">Search "epsg:4326" in ESRI</a></li>
+        <li></li>
         <li><a href="./ref/epsg/2000/">EPSG 2000</a></li>
         <li>Per CRS
             <ul>


### PR DESCRIPTION
This PR has two parts related with the search functionality in JavaScript code:

- Give some meaningful output when the user searches `WGS84` (all together). The name of the CRS in EPSG is `WGS 84` with a space. Before this PR searching WGS84 was not giving any result from EPSG. No writing the space is something usual (including myself).
- Searching for a string like `EPSG:4326` should return the correspondent CRS. Before this PR the behaviour was different in the general search and in the authority search.