### PR TITLE
Upgrade to PROJ 9.3.1

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 # indicate DOCKER PROJ version
-PROJ_VERSION=9.3.0
+PROJ_VERSION=9.3.1
 PYPROJ_VERSION=3.6.1
 LAST_REVISED=2024
 TAG="crs-explorer:$PROJ_VERSION"


### PR DESCRIPTION
Upgrading PROJ to 9.3.1

This is an example of how easy is the upgrade:

- Sync your fork with upstream.
- Change the version of PROJ (as in this PR)
- Create a PR