### PR TITLE
Deprecated links

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -159,6 +159,14 @@ def url_to_xml(prefix, file):
     str += f'    </url>\n'
     return str
 
+def non_deprecated_info(to_authority, crss):
+    auth_name = to_authority[0]
+    code = to_authority[1]
+    entry = next(x for x in crss if x['auth_name'] == auth_name and x['code'] == code)
+    return {'url': f'../../{auth_name.lower()}/{code}',
+            'text': f'{auth_name}:{code}',
+            'title': entry['name'] if entry else '',}
+
 def main():
     dest_dir = os.getenv('DEST_DIR', '.')
     g = Generator()
@@ -269,6 +277,7 @@ def main():
                'area_name': aou[4] if aou else 'Unknown',
                'epsg_scaped_name': epsg_scaped_name,
                'deprecated': c.get("deprecated", False),
+               'non_deprecated': [non_deprecated_info(x.to_authority(), crss) for x in crs.get_non_deprecated()],
                'crs_type': c.get("type", '--'),
                'bounds': bounds,
                'bounds_map': bounds if aou and auth_lowercase[0:3] != 'iau' else None,

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 # indicate DOCKER PROJ version
 PROJ_VERSION=9.4.0
-PYPROJ_VERSION=3.6.1
+PYPROJ_VERSION=7aab7d91e14230d846f74c418810652859d3c69d # fixing 3.6.1
 LAST_REVISED=2024
 TAG="crs-explorer:$PROJ_VERSION"
 

--- a/scripts/templates/crs.tmpl
+++ b/scripts/templates/crs.tmpl
@@ -53,7 +53,13 @@
             </li>
             {%- endif %}
             {%- if deprecated %}
-            <li class="darkred"><b>Deprecated!</b></li>
+            <li><b class="darkred">Deprecated!</b>
+                {%- if non_deprecated %}
+                See {%- for nodep in non_deprecated|sort(attribute='text') %}
+<a href="{{ nodep.url }}" title="{{ nodep.title}}">{{ nodep.text }}</a>{{ ", " if not loop.last else "" }}
+                {%- endfor %} instead.
+                {%- endif %}
+            </li>
             {%- endif %}
         </ul>
         {%- endif %}


### PR DESCRIPTION
Adds information about alternative for deprecated CRSs

@mwtoews do you think we should wait for pyproj 3.7.0, or we merge now with that hash in the setup in PYPROJ_VERSION? I have no hurry, just developed it this weekend.

You have a preview at sr-org-scratch.github.io

Closes  #3 