### PR TITLE
Add some metadata for SEO

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -229,7 +229,7 @@ def main():
     crss = make_crslist(dest_dir)
 
     # copy some literal files, not modified
-    for literal in ['base.js', 'base.css', 'sr_logo.jpg', 'favicon.ico', 'tests.html']:
+    for literal in ['base.js', 'base.css', 'sr_logo.jpg', 'favicon.ico', 'tests.html', 'robots.txt']:
         shutil.copy(f'./templates/{literal}', dest_dir)
 
     authorities = {

--- a/scripts/templates/about.tmpl
+++ b/scripts/templates/about.tmpl
@@ -3,6 +3,8 @@
 <head>
     {% include 'sections/head.tmpl' %}
     <title>About -- Spatial Reference</title>
+    <meta name="keywords" content="epsg, esri, iau, ignf, nkg, ogc, coordinate system, srs, crs" >
+    <meta name="description" content="Spatial Reference catalog of coordinate reference systems" >
 </head>
 
 <body>

--- a/scripts/templates/crs.tmpl
+++ b/scripts/templates/crs.tmpl
@@ -3,6 +3,8 @@
 <head>
     {% include 'sections/head.tmpl' %}
     <title>{{ authority }}:{{ code }} {{ name }} -- Spatial Reference</title>
+    <meta name="keywords" content="{{ authority }}, {{ code }}, {{ name }}, coordinate system, srs, crs" >
+    <meta name="description" content="{{ authority }}:{{ code }} {{ name }} - spatial reference system" >
     {% include 'sections/leaflet.tmpl' %}
 </head>
 

--- a/scripts/templates/htmlwkt.tmpl
+++ b/scripts/templates/htmlwkt.tmpl
@@ -3,6 +3,8 @@
 <head>
     {% include 'sections/head.tmpl' %}
     <title>{{ authority }}:{{ code }}{{ wkt_type }} -- Spatial Reference</title>
+    <meta name="keywords" content="{{ authority }}, {{ code }}, {{ 'WKT2' if wkt_type else 'WKT' }}, coordinate system, srs, crs" >
+    <meta name="description" content="{{ authority }}:{{ code }} {{ 'WKT2' if wkt_type else 'WKT' }}" >
 </head>
 
 <body>

--- a/scripts/templates/index.tmpl
+++ b/scripts/templates/index.tmpl
@@ -3,6 +3,8 @@
 <head>
     {% include 'sections/head.tmpl' %}
     <title>Home -- Spatial Reference</title>
+    <meta name="keywords" content="epsg, esri, iau, ignf, nkg, ogc, coordinate system, srs, crs" >
+    <meta name="description" content="Spatial Reference catalog of coordinate reference systems" >
 </head>
 
 <body>

--- a/scripts/templates/ref.tmpl
+++ b/scripts/templates/ref.tmpl
@@ -3,6 +3,8 @@
 <head>
     {% include 'sections/head.tmpl' %}
     <title>Spatial Reference List -- Spatial Reference</title>
+    <meta name="keywords" content="{{ authority if authority else '' }}, coordinate system, srs, crs" >
+    <meta name="description" content="{{ authority if authority else '' }} - spatial reference systems" >
 </head>
 
 <body>

--- a/scripts/templates/robots.txt
+++ b/scripts/templates/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://spatialreference.org/sitemap.xml

--- a/scripts/templates/versions.tmpl
+++ b/scripts/templates/versions.tmpl
@@ -3,6 +3,8 @@
 <head>
     {% include 'sections/head.tmpl' %}
     <title>Versions -- Spatial Reference</title>
+    <meta name="keywords" content="epsg, esri, iau, ignf, nkg, ogc, coordinate system, srs, crs" >
+    <meta name="description" content="Spatial Reference catalog of coordinate reference systems" >
 </head>
 
 <body>


### PR DESCRIPTION
Adds `keywords` and `description` meta to html pages. Also `robots.txt` file. The `sitemap.xml` was already there.

Closes #24