### PR TITLE
Add machine-readable PROJJSON listing

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM ghcr.io/osgeo/proj:${VERSION:-9.5.0}
+FROM --platform=linux/amd64 ghcr.io/osgeo/proj:${VERSION:-9.5.0}
 
 ARG PYPROJ_VERSION 3.3.0
 ENV PYPROJ_VERSION=$PYPROJ_VERSION

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM --platform=linux/amd64 ghcr.io/osgeo/proj:${VERSION:-9.5.0}
+FROM ghcr.io/osgeo/proj:${VERSION:-9.5.0}
 
 ARG PYPROJ_VERSION 3.3.0
 ENV PYPROJ_VERSION=$PYPROJ_VERSION

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -89,6 +89,8 @@ def make_projjson_index(dest_dir, crss):
     with open(dest_file, 'w') as fp:
         json.dump(index, fp, indent=2)
 
+    shutil.copy(f'./templates/projjson_index-schema.json', f'{dest_dir}/projjson_index-schema.json')
+
 def make_crslist(dest_dir):
     dest_file = f'{dest_dir}/crslist.json'
 

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -74,21 +74,10 @@ def add_frozen_crss(crss):
             crss = [*crss, *dom]
     return crss
 
-def make_projjson_index(dest_dir):
+def make_projjson_index(dest_dir, crss):
     dest_file = f'{dest_dir}/projjson_index.json'
 
-    pyproj.show_versions()
-
-    crs_list = pyproj.database.query_crs_info(allow_deprecated=True)
-
-    crss = sorted(
-        [crs._asdict() for crs in crs_list if crs.area_of_use],
-        key=lambda d: d['auth_name'] + d['code'].zfill(7)
-    )
-
-    crss = add_frozen_crss(crss)
-
-    crss2 = [
+    index = [
         {
             "auth_name": crs["auth_name"],
             "code": crs["code"],
@@ -98,7 +87,7 @@ def make_projjson_index(dest_dir):
     ]
 
     with open(dest_file, 'w') as fp:
-        json.dump(crss2, fp, indent=2)
+        json.dump(index, fp, indent=2)
 
 def make_crslist(dest_dir):
     dest_file = f'{dest_dir}/crslist.json'

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -74,6 +74,32 @@ def add_frozen_crss(crss):
             crss = [*crss, *dom]
     return crss
 
+def make_projjson_index(dest_dir):
+    dest_file = f'{dest_dir}/projjson_index.json'
+
+    pyproj.show_versions()
+
+    crs_list = pyproj.database.query_crs_info(allow_deprecated=True)
+
+    crss = sorted(
+        [crs._asdict() for crs in crs_list if crs.area_of_use],
+        key=lambda d: d['auth_name'] + d['code'].zfill(7)
+    )
+
+    crss = add_frozen_crss(crss)
+
+    crss2 = [
+        {
+            "auth_name": crs["auth_name"],
+            "code": crs["code"],
+            "link": f"./ref/{crs['auth_name'].lower()}/{crs['code'].lower()}/projjson.json",
+        }
+        for crs in crss
+    ]
+
+    with open(dest_file, 'w') as fp:
+        json.dump(crss2, fp, indent=2)
+
 def make_crslist(dest_dir):
     dest_file = f'{dest_dir}/crslist.json'
 
@@ -226,6 +252,7 @@ def main():
     sitemap_file = f'{dest_dir}/sitemap.xml'
     urls = []
 
+    make_projjson_index(dest_dir)
     crss = make_crslist(dest_dir)
 
     # copy some literal files, not modified

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -81,7 +81,7 @@ def make_projjson_index(dest_dir, crss):
         {
             "auth_name": crs["auth_name"],
             "code": crs["code"],
-            "link": f"./ref/{crs['auth_name'].lower()}/{crs['code'].lower()}/projjson.json",
+            "link": f"./ref/{crs['auth_name'].lower()}/{crs['code']}/projjson.json",
         }
         for crs in crss
     ]

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -89,8 +89,6 @@ def make_projjson_index(dest_dir, crss):
     with open(dest_file, 'w') as fp:
         json.dump(index, fp, indent=2)
 
-    shutil.copy(f'./templates/projjson_index-schema.json', f'{dest_dir}/projjson_index-schema.json')
-
 def make_crslist(dest_dir):
     dest_file = f'{dest_dir}/crslist.json'
 
@@ -248,7 +246,8 @@ def main():
 
     # copy some literal files, not modified
     for literal in ['base.js', 'explorer.js', 'base.css', 'explorer.css',
-                     'sr_logo.jpg', 'favicon.ico', 'tests.html', 'robots.txt']:
+                     'sr_logo.jpg', 'favicon.ico', 'tests.html', 'robots.txt',
+                     'projjson_index-schema.json']:
         shutil.copy(f'./templates/{literal}', dest_dir)
 
     authorities = {

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -241,8 +241,8 @@ def main():
     sitemap_file = f'{dest_dir}/sitemap.xml'
     urls = []
 
-    make_projjson_index(dest_dir)
     crss = make_crslist(dest_dir)
+    make_projjson_index(dest_dir, crss)
 
     # copy some literal files, not modified
     for literal in ['base.js', 'explorer.js', 'base.css', 'explorer.css',

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -14,7 +14,7 @@ mkdir -p $DIRNAME/dist
 test "$(ls -A $DIRNAME/dist/)" && rm -r $DIRNAME/dist/*
 
 # build container
-docker build --pull --build-arg VERSION=$PROJ_VERSION --build-arg PYPROJ_VERSION=$PYPROJ_VERSION --tag $TAG $DIRNAME
+docker build --pull --platform=linux/amd64 --build-arg VERSION=$PROJ_VERSION --build-arg PYPROJ_VERSION=$PYPROJ_VERSION --tag $TAG $DIRNAME
 
 # execute container
 docker run --user $(id -u):$(id -g) -e STOP_COUNTER=$STOP_COUNTER -e LAST_REVISED=$LAST_REVISED -e PROJ_VERSION=$PROJ_VERSION --rm -v "$DIRNAME/dist:/home/dist" $TAG

--- a/scripts/templates/projjson_index-schema.json
+++ b/scripts/templates/projjson_index-schema.json
@@ -12,11 +12,11 @@
     "properties": {
       "auth_name": {
         "type": "string",
-        "description": "CRS authority name, e.g. EPSG, ESRI, and OGC"
+        "description": "CRS authority name, e.g. EPSG, ESRI, OGC"
       },
       "code": {
         "type": "string",
-        "description": "CRS code, e.g. '4326' or '2181', and 'CRS84'"
+        "description": "CRS code, e.g. 4326, 2181, CRS84"
       },
       "link": {
         "type": "string",

--- a/scripts/templates/projjson_index-schema.json
+++ b/scripts/templates/projjson_index-schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "description": "Array mapping from CRS authority code to PROJJSON representations",
+  "items": {
+    "type": "object",
+    "required": [
+      "auth_name",
+      "code",
+      "link"
+    ],
+    "properties": {
+      "auth_name": {
+        "type": "string",
+        "description": "CRS authority name, e.g. EPSG, ESRI, and OGC"
+      },
+      "code": {
+        "type": "string",
+        "description": "CRS code, e.g. '4326' or '2181', and 'CRS84'"
+      },
+      "link": {
+        "type": "string",
+        "description": "Relative link to PROJJSON representation of CRS"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Create `projjson_index.json` file with links to each PROJJSON representation, per @jjimenezshaw feedback in https://github.com/opengeospatial/geoparquet/issues/262#issuecomment-2931683990 

The new URL https://spatialreference.org/projjson_index.json will be usable in the Geoparquet spec to provide support for 4-byte SRIDs in the style of PostGIS `spatial_ref_sys` table without requiring full repeated storage of long JSON objects.

The schema of the new index file documenting the meaning of its fields will be found at https://spatialreference.org/projjson_index-schema.json