### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# `dependabot.yml` file with updates
+
+# Update manually "Insights -> Dependency Graph -> Dependabot" 
+
+version: 2
+updates:
+  # Configuration for Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/scripts/"
+    schedule:
+      interval: "daily"
+  
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,4 @@
-ARG VERSION
-FROM ghcr.io/osgeo/proj:${VERSION:-9.5.0}
+FROM ghcr.io/osgeo/proj:9.6.2
 
 ARG PYPROJ_VERSION 3.3.0
 ENV PYPROJ_VERSION=$PYPROJ_VERSION

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -124,11 +124,11 @@ def make_crslist(dest_dir):
 
 def make_mapping(home_dir):
     today = date.today().isoformat()
+    proj_version = pyproj.database.get_database_metadata("PROJ.VERSION")
     mapping = {'home_dir': home_dir,
                'lang': 'en',
                'authority': None,
-               'last_revised': os.getenv('LAST_REVISED', '-missing-'),
-               'proj_version': os.getenv('PROJ_VERSION', '-missing-'),
+               'proj_version': proj_version,
                'built_date': today,}
     return mapping
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,23 +1,25 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# indicate DOCKER PROJ version
-PROJ_VERSION=9.6.2
-PYPROJ_VERSION=3.7.1
-LAST_REVISED=2025
-TAG="crs-explorer:$PROJ_VERSION"
-STOP_COUNTER="${1:-0}"
-
 # prepare destination
 DIRNAME=`dirname $(readlink -f $0)`
 mkdir -p $DIRNAME/dist
 test "$(ls -A $DIRNAME/dist/)" && rm -r $DIRNAME/dist/*
 
+# extract PROJ version from Dockerfile
+PROJ_VERSION=`cat $DIRNAME/Dockerfile | sed -n 's/^FROM .*:\(.*\)$/\1/p'`
+echo "PROJ_VERSION=$PROJ_VERSION"
+
+PYPROJ_VERSION=3.7.1
+
+DOCKER_TAG="crs-explorer:$PROJ_VERSION"
+STOP_COUNTER="${1:-0}"
+
 # build container
-docker build --pull --platform=linux/amd64 --build-arg VERSION=$PROJ_VERSION --build-arg PYPROJ_VERSION=$PYPROJ_VERSION --tag $TAG $DIRNAME
+docker build --pull --platform=linux/amd64 --build-arg PYPROJ_VERSION=$PYPROJ_VERSION --tag $DOCKER_TAG $DIRNAME
 
 # execute container
-docker run --user $(id -u):$(id -g) -e STOP_COUNTER=$STOP_COUNTER -e LAST_REVISED=$LAST_REVISED -e PROJ_VERSION=$PROJ_VERSION --rm -v "$DIRNAME/dist:/home/dist" $TAG
+docker run --user $(id -u):$(id -g) -e STOP_COUNTER=$STOP_COUNTER --rm -v "$DIRNAME/dist:/home/dist" $DOCKER_TAG
 
 # done
 echo .

--- a/scripts/templates/index.tmpl
+++ b/scripts/templates/index.tmpl
@@ -59,7 +59,6 @@
             <p>Click the Map to open the Explorer</p>
             <img src="https://a.tile.openstreetmap.org/0/0/0.png">
         </a>
-        <p>Last revised in {{ last_revised }}</p>
     </div>
     <div id="footer">
         {% include 'sections/footer.tmpl' %} - Code implementation inspired by <a href="https://crs-explorer.proj.org">crs-explorer.proj.org</a>


### PR DESCRIPTION
Dependabot checks the version of PROJ daily and other github-actions monthly.
In case of a new PROJ docker image published in github, a PR is automatically generated.

You can check how it worked in https://github.com/OSGeo/PROJ-CRS-Explorer

"Last revised in " is removed as it is redundant with the build date, present in the footer.